### PR TITLE
Add decoding; error & bulk string server encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,29 @@ protocol.
 Decoding
 --------
 
-**TODO**
+eresp decoding is fairly straight-forward and converts binary RESP strings to
+Erlang terms.
+
+The table of RESP to Erlang decoding rules is in the edoc documentation.
+
+Decoding is fairly simple, however:
+
+```erlang
+RESP = <<"$3\r\nFoo\r\n$3\r\nbar\r\n">>.
+
+% Parse first term
+{ok, Term1, Rest1} = eresp:decode(RESP).
+io:format("Term1 = ~s~n", [Term1]).
+% => Term1 = foo
+
+% Parse next term
+{ok, Term2, Rest2} = eresp:decode(Rest1).
+io:format("Term2 = ~s~n", [Term2]).
+% => Term2 = bar
+
+% Done
+{error, eof} = eresp:decode(Rest2).
+```
 
 Encoding
 --------
@@ -24,25 +46,17 @@ and servers have the full range of types supported by Redis.
 Maps and tuples are not supported when encoding. Pids, ports, and other types
 that are specific to Erlang are also unsupported.
 
-eresp encode/1, encode/2, cmd/1, cmd/2, and resp/1 output is always an iolist or
-an `{error, Reason}` tuple.
+eresp encode/1, encode/2, cmd/1, and cmd/2 output is always an iolist or an
+`{error, Reason}` tuple.
 
 ### Server Encoding
 
-This is the default encoding when using encode/1, encode/2, and is what is used
-with the convenience function resp/1. It's recommended to use resp/1 to ensure
-your code is clear about its intent (i.e., is creating a server RESP response).
+This is the default encoding when using encode/1 (server encoding) and encode/2.
+It's recommended to use resp/1 to ensure your code is clear about its intent
+(i.e., is creating a server RESP response).
 
-- `'nil'` is a nil bulk string.
-- `'true'` and `'false'` are encoded as integers `1` and `0`.
-- `'ok'` is encoded as the simple string `OK`.
-- Integers are encoded as integers.
-- Floats are encoded as bulk strings.
-  This is done with `float_to_binary(F, [{decimal, 14}, compact])`.
-- Lists are always encoded as arrays -- no effort is made to treat a list as
-  a bulk string.
-- Atoms other than booleans, `'ok'`, and `'nil'` are encoded as bulk strings.
-- Binaries are always bulk strings.
+The full encoding table for server messages can be seen in the edoc
+documentation.
 
 ### Client Encoding
 

--- a/src/eresp.erl
+++ b/src/eresp.erl
@@ -12,135 +12,444 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
+%% @doc eresp is a package for encoding and decoding the Redis serialization
+%% protocol (RESP).
 -module(eresp).
 
 %% API exports
 -export([encode/1, encode/2]).
 -export([cmd/1, cmd/2]).
--export([resp/1]).
+-export([decode/1]).
 
 -type command() :: atom() | binary() | nonempty_string().
+-type resp_error() :: {error, string() | binary()}.
 -type resp_scalar() :: number() | iolist() | string() | binary() | atom() | boolean() | 'nil'.
--type resp_term() :: resp_scalar() | list(resp_term()).
+-type resp_term() :: resp_scalar() | resp_error() | resp_terms().
 -type resp_terms() :: list(resp_term()).
 -type options() :: #{
         mode => client | server | none()
        }.
+
 -type error() :: {error, Reason :: term()}.
+-type bad_resp_error() :: {error,
+                           {bad_resp,
+                            list(integer
+                                 | simple_string
+                                 | bulk_string
+                                 | array
+                                 | error
+                                 | unknown)}}.
+-type decoded_term() :: {ok, Term :: resp_term(), Rest :: binary()}.
 
 %%====================================================================
 %% API functions
 %%====================================================================
 
+%% Encoding
+
 %% @equiv encode(Term, #{})
 encode(Term) ->
-   encode(Term, #{}).
+  encode(Term, #{}).
 
--spec encode(Term :: resp_term(), Options :: options()) -> iolist() | error().
+%% @doc Encodes an Erlang term using the given options. If the Term cannot be
+%% encoded, it fails with a `badarg' error.
+%%
+%% Options may include a `mode' key, which if set to `client' will encode all
+%% terms passed as bulk strings. To produce a flat list suitable for client
+%% encoding of a command, you can use the `cmd/2' function.
+%%
+%% By default, if no options are given (i.e., Options is an empty map), server
+%% encoding is used. For common cases using server encoding, you should prefer
+%% using `encode/1'.
+%%
+%% === Client Encoding ===
+%%
+%% The following types can be encoded as bulk strings in client encoding:
+%%
+%% <ul>
+%% <li>IOLists</li>
+%% <li>Binaries</li>
+%% <li>Integers</li>
+%% <li>Floats</li>
+%% <li>Atoms</li>
+%% </ul>
+%%
+%% === Server Encoding ===
+%%
+%% The following table details how different Erlang terms are encoded in RESP:
+%%
+%% <table border="1">
+%%   <tr>
+%%     <th width="20%">Erlang</th>
+%%     <th>RESP</th>
+%%   </tr>
+%%   <tr>
+%%     <td>12345 (Integer)</td>
+%%     <td>Integers.</td>
+%%   </tr>
+%%   <tr>
+%%     <td>123.45 (Float)</td>
+%%     <td>
+%%       A bulk string, encoded in compact form with up to 14 decimals. If you
+%%       need more or fewer digits, convert your float to a string ahead of time
+%%       to ensure it's encoded as desired.
+%%     </td>
+%%   </tr>
+%%   <tr>
+%%     <td>Binaries</td>
+%%     <td>Bulk strings.</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Lists</td>
+%%     <td>Encoded as arrays.</td>
+%%   </tr>
+%%   <tr>
+%%     <td>`{bulk, IOList}'</td>
+%%     <td>
+%%       Bulk strings. This allows using an IOList for a bulk string when
+%%       performing server encoding, as lists are encoded as arrays.
+%%     </td>
+%%   </tr>
+%%   <tr>
+%%     <td>
+%%       `{error, Message}'<br/>
+%%       `{error, {Class, Reason}}'
+%%     </td>
+%%     <td>
+%%       Errors. If the second form is used, `Class' and `Reason' are encoded
+%%       into a single error message of the form `CLASS Reason', and `Class' is
+%%       uppercased, as in common Redis error messages.
+%%
+%%       `Class', `Reason', and `Message' may be an atom, string, or binary
+%%       string.
+%%     </td>
+%%   </tr>
+%%   <tr>
+%%     <td>`` 'ok' ''</td>
+%%     <td>The simple string `OK'.</td>
+%%   </tr>
+%%   <tr>
+%%     <td>`` 'nil' ''</td>
+%%     <td>
+%%       A null bulk string. Although semantically equivalent to a null bulk
+%%       array, the null array is never used in encoding in eresp.
+%%     </td>
+%%   </tr>
+%%   <tr>
+%%     <td>`` 'true' '', `` 'false' ''</td>
+%%     <td>RESP integers 1 and 0, respectively.</td>
+%%   </tr>
+%% </table>
+%%
+%% @see cmd/2
+-spec encode(Term :: resp_term(), Options :: options()) -> iolist().
 encode(Term, #{mode := client} = Options) ->
-   try encode_client(Term, Options)
-   catch error:Reason -> {error, Reason} end;
+  encode_client(Term, Options);
 encode(Term, Options) ->
-   try encode_server(Term, Options)
-   catch error:Reason -> {error, Reason} end.
-
--spec resp(Term :: resp_term()) -> iolist() | error().
-resp(Term) ->
-   encode(Term, #{}).
+  encode_server(Term, Options).
 
 %% @equiv cmd(Command, [])
 -spec cmd(Command :: command()) -> iolist() | error().
 cmd(Command) ->
-   cmd(Command, []).
+  cmd(Command, []).
 
+%% @doc Encodes a client command as a flat array of bulk strings, containing
+%% Command as its command and Args as the arguments to that command.
+%%
+%% This is intended for use as the client encoding when sending commands to
+%% a Redis or RESP-compatible server.
 -spec cmd(Command :: command(), Args :: resp_terms()) -> iolist() | error().
 cmd(Command, Args) when is_atom(Command), is_list(Args) ->
-   cmd(atom_to_binary(Command, utf8), Args);
+  cmd(atom_to_binary(Command, utf8), Args);
 cmd(Command, Args) when is_binary(Command), is_list(Args);
                         is_list(Command), is_list(Args) ->
-   encode_list([upper(Command)|Args], #{mode => client}).
+  encode_array([upper(Command)|Args], #{mode => client}).
+
+%% Decoding
+
+%% @doc Decodes a binary string as RESP, returning Erlang terms representing
+%% the elements of the RESP provided.
+%%
+%% If decoding is successful, returns the tuple `{ok, Term, Rest}', where Term
+%% is an Erlang term representing the decoded RESP, and Rest is the tail of Bin
+%% that was not parsed.
+%%
+%% If there is an error decoding Bin (because the RESP is invalid), the result
+%% is {error, {bad_resp, Stack}}, where Stack is a list of atoms showing the
+%% parsing stack. Often, the last element is the most relevant -- the last is
+%% the element decode thought it was parsing and failed to handle. In cases
+%% where the binary makes no sense at all, the atom is `` 'unknown' ''.
+%%
+%% === Decoding Table ===
+%%
+%% <table border="1">
+%%   <tr>
+%%     <th>RESP Type</th>
+%%     <th>Erlang Type</th>
+%%   </tr>
+%%   <tr>
+%%     <td>Simple String "OK"</td>
+%%     <td>`` 'ok' ''</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Simple String</td>
+%%     <td>Binaries: `<<"Simple String">>'</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Bulk String</td>
+%%     <td>Binaries: `<<"Bulk String">>'</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Array</td>
+%%     <td>Lists</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Integer</td>
+%%     <td>Integer</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Bulk Nil (Array / String)</td>
+%%     <td>`` 'nil' ''</td>
+%%   </tr>
+%%   <tr>
+%%     <td>Errors</td>
+%%     <td>`{error, <<"ERROR description">>}'</td>
+%%   </tr>
+%% </table>
+-spec decode(binary()) -> decoded_term() | bad_resp_error().
+decode(Bin) when is_binary(Bin) ->
+  try decode_binary(Bin) of
+    {Term, Rest} ->
+      {ok, Term, Rest}
+  catch
+    error:Reason ->
+      {error, Reason}
+  end.
 
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
+%% Encoding
+
 encode_client(List, _Options) when is_list(List) ->
-   encode_bulk_string(List);
+  encode_bulk_string(List);
 encode_client(Integer, _Options) when is_integer(Integer) ->
-   encode_bulk_string(integer_to_binary(Integer, 10));
+  encode_bulk_string(integer_to_binary(Integer, 10));
 encode_client(Term, Options) ->
-   encode_term(Term, Options).
+  encode_term(Term, Options).
 
 encode_server(nil, _Options) ->
-   encode_nil();
+  encode_nil();
 encode_server(true, _Options) ->
-   encode_integer(1);
+  encode_integer(1);
 encode_server(false, _Options) ->
-   encode_integer(0);
+  encode_integer(0);
 encode_server(ok, _Options) ->
-   encode_simple_string(<<"OK">>);
+  encode_ok();
+encode_server({bulk, String}, _Options) when is_binary(String); is_list(String) ->
+  encode_bulk_string(String);
+encode_server({bulk, _String}, _Options) ->
+  error(bad_iolist);
+encode_server({error, Reason}, _Options) ->
+  encode_error(Reason);
 encode_server(Term, Options) ->
-   encode_term(Term, Options).
+  encode_term(Term, Options).
 
 -define(CRLF, "\r\n").
 -define(EMPTY_BULK_STRING, <<$$, "0", ?CRLF, ?CRLF>>).
 
 encode_nil() ->
-   [<<"$-1" ?CRLF>>].
+  [<<"$-1" ?CRLF>>].
 
 encode_integer(Integer) when is_integer(Integer) ->
-   [$:, integer_to_binary(Integer, 10), <<?CRLF>>].
+  [$:, integer_to_binary(Integer, 10), <<?CRLF>>].
 
 encode_float(Float) when is_float(Float) ->
-   encode_bulk_string(float_to_binary(Float, [{decimals, 14}, compact])).
+  encode_bulk_string(float_to_binary(Float, [{decimals, 14}, compact])).
 
 encode_bulk_string(<<>>) ->
-   [?EMPTY_BULK_STRING];
+  ?EMPTY_BULK_STRING;
 encode_bulk_string([]) ->
-   [?EMPTY_BULK_STRING];
+  ?EMPTY_BULK_STRING;
 encode_bulk_string(String) when is_binary(String) ->
-   [$$, integer_to_binary(byte_size(String), 10), <<?CRLF>>, String, <<?CRLF>>];
+  [$$, integer_to_binary(byte_size(String), 10), <<?CRLF>>, String, <<?CRLF>>];
 encode_bulk_string(IOList) when is_list(IOList) ->
-   try [$$, integer_to_binary(iolist_size(IOList), 10), <<?CRLF>>, IOList, <<?CRLF>>]
-   catch error:badarg -> error(bad_iolist) end.
+  try iolist_size(IOList) of
+    Size ->
+      [$$, integer_to_binary(Size, 10), <<?CRLF>>, IOList, <<?CRLF>>]
+  catch
+    error:badarg ->
+      error(bad_iolist)
+  end.
 
--spec encode_list(resp_terms(), options()) -> iolist().
-encode_list([], _Options) ->
-   [<<$*, "0", ?CRLF>>];
-encode_list(List, Options) when is_list(List) ->
-   [$*, integer_to_binary(length(List)), <<?CRLF>>,
-    [encode(Term, Options) || Term <- List], <<?CRLF>>].
+-spec encode_array(resp_terms(), options()) -> iolist().
+encode_array([], _Options) ->
+  [<<$*, "0", ?CRLF, ?CRLF>>];
+encode_array(List, Options) when is_list(List) ->
+  [$*, integer_to_binary(length(List)), <<?CRLF>>,
+   [encode(Term, Options) || Term <- List], <<?CRLF>>].
 
--spec encode_simple_string(binary() | iolist()) -> iolist().
-encode_simple_string(<<"OK">>) ->
-   [<<$+, "OK" ?CRLF>>];
-encode_simple_string(Str) when is_binary(Str); is_list(Str) ->
-   [$+, Str, <<?CRLF>>].
+-spec encode_ok() -> iolist().
+encode_ok() ->
+  [<<$+, "OK", ?CRLF>>].
+
+encode_error(Str) when is_binary(Str); is_list(Str) ->
+  [$-, simple_string(Str), <<?CRLF>>];
+encode_error({Class, Reason})
+  when is_atom(Class) orelse is_binary(Class) orelse is_list(Class);
+       is_atom(Reason) orelse is_binary(Reason) orelse is_list(Reason) ->
+  [$-, upper(simple_string(Class)), <<" ">>, simple_string(Reason), <<?CRLF>>].
+
+not_crlf(Char) ->
+  Char =/= $\r andalso Char =/= $\n.
+
+simple_string(Str) when is_binary(Str) ->
+  case binary:split(Str, [<<$\r>>, <<$\n>>]) of
+    [Str] ->
+      Str;
+    _Error ->
+      error(badarg)
+  end;
+simple_string(Str) when is_list(Str) ->
+  case lists:splitwith(fun not_crlf/1, Str) of
+    {Str, []} ->
+      Str;
+    _Error ->
+      error(badarg)
+  end;
+simple_string(Str) when is_atom(Str) ->
+  simple_string(atom_to_binary(Str, utf8)).
 
 -spec encode_atom(atom()) -> iolist().
 encode_atom(Atom) when is_atom(Atom) ->
-   encode_bulk_string(erlang:atom_to_binary(Atom, utf8)).
+  encode_bulk_string(erlang:atom_to_binary(Atom, utf8)).
 
 -spec encode_term(resp_term(), options()) -> iolist().
 encode_term(Atom, _Options) when is_atom(Atom) ->
-   encode_atom(Atom);
+  encode_atom(Atom);
 encode_term(Binary, _Options) when is_binary(Binary) ->
-   encode_bulk_string(Binary);
+  encode_bulk_string(Binary);
 encode_term(Integer, _Options) when is_integer(Integer) ->
-   encode_integer(Integer);
+  encode_integer(Integer);
 encode_term(Float, _Options) when is_float(Float) ->
-   encode_float(Float);
+  encode_float(Float);
 encode_term(List, Options) when is_list(List) ->
-   encode_list(List, Options);
+  encode_array(List, Options);
 encode_term(_Term, _Options) ->
-   error(badarg).
+  error(badarg).
 
 -spec upper(binary()) -> binary();
            (string()) -> string().
 upper(Bin) when is_binary(Bin) ->
-   << <<(if C >= $a, C =< $z -> C - $a + $A; true -> C end)>>
-      || <<C>> <= Bin >>;
+  << <<(if C >= $a, C =< $z -> C - $a + $A; true -> C end)>>
+     || <<C>> <= Bin >>;
 upper(List) when is_list(List) ->
-   [ (if C >= $a, C =< $z -> C - $a + $A; true -> C end)
-     || C <- List ].
+  [ (if C >= $a, C =< $z -> C - $a + $A; true -> C end)
+    || C <- List ].
+
+%% Decoding
+
+-spec decode_binary(binary()) -> {resp_term(), binary()} | no_return().
+decode_binary(<<$+, Rest/binary>> = _Bin) ->
+  decode_simple_string(Rest);
+decode_binary(<<$$, Rest/binary>> = _Bin) ->
+  decode_bulk_string(Rest);
+decode_binary(<<$*, Rest/binary>> = _Bin) ->
+  io:format("decode array~n"),
+  decode_array(Rest);
+decode_binary(<<$:, Rest/binary>> = _Bin) ->
+  decode_integer(Rest);
+decode_binary(<<$-, Rest/binary>> = _Bin) ->
+  decode_error(Rest);
+decode_binary(<<>>) ->
+  error(eof);
+decode_binary(_Bin) ->
+  error({bad_resp, [unknown]}).
+
+-spec decode_simple_string(binary()) -> {binary() | 'ok', binary()} | no_return().
+decode_simple_string(Bin) ->
+  read_simple_string(simple_string, Bin).
+
+-spec decode_bulk_string(binary()) -> {binary() | 'nil', binary()} | no_return().
+decode_bulk_string(<<"-1\r\n", Rest/binary>>) ->
+  {'nil', Rest};
+decode_bulk_string(Bin) ->
+  try decode_integer(Bin) of
+    {Length, Rest0} when Length >= 0 ->
+      case Rest0 of
+        <<Str:Length/binary, "\r\n", Rest/binary>> ->
+          {Str, Rest};
+        _Error ->
+          error({bad_resp, [bulk_string]})
+      end;
+    _Error ->
+      error({bad_resp, [bulk_string]})
+  catch
+    error:{bad_resp, [_Pred|Tail]} ->
+      error({bad_resp, [bulk_string|Tail]})
+  end.
+
+-spec decode_array(binary()) -> {resp_terms() | 'nil', binary()} | no_return().
+decode_array(<<"-1\r\n", Rest/binary>>) ->
+  {'nil', Rest};
+decode_array(Bin) ->
+  io:format("decode bulk array~n"),
+  try decode_integer(Bin) of
+    {0, <<"\r\n", Rest0/binary>>} ->
+      {[], Rest0};
+    {Length, Rest0} when Length > 0 ->
+      io:format("decode bulk array N=~w~n", [Length]),
+      case  decode_array_n(Rest0, Length, []) of
+        {List, <<"\r\n", Rest1/binary>>} ->
+          {List, Rest1};
+        _Error ->
+          error({bad_resp, [array]})
+      end;
+    _Error ->
+      error({bad_resp, [array]})
+  catch
+    error:{bad_resp, [_Pred|Tail]} ->
+      error({bad_resp, [array|Tail]})
+  end.
+
+-spec decode_array_n(binary(), non_neg_integer(), resp_terms()) -> {resp_terms(), binary()} | no_return().
+decode_array_n(Bin, 0, Accum) ->
+  {lists:reverse(Accum), Bin};
+decode_array_n(Bin, N, Accum) when N > 0 ->
+  io:format("reading array element~n"),
+  case decode(Bin) of
+    {ok, Term, Rest} ->
+      io:format("read array element~n"),
+      decode_array_n(Rest, N-1, [Term|Accum]);
+    {error, {bad_resp, Tail}} ->
+      error({bad_resp, [array|Tail]})
+  end.
+
+-spec decode_integer(binary()) -> {integer(), binary()} | no_return().
+decode_integer(Bin) ->
+  {Str, Rest} = read_simple_string(integer, Bin),
+  try binary_to_integer(Str, 10) of
+    Int ->
+      {Int, Rest}
+  catch
+    error:badarg ->
+      error({bad_resp, [integer]})
+  end.
+
+-spec decode_error(binary()) -> {resp_error(), binary()} | no_return().
+decode_error(Bin) ->
+  {Reason, Rest} = read_simple_string(error, Bin),
+  {{error, Reason}, Rest}.
+
+-spec read_simple_string(atom(), binary()) -> {ok | binary(), binary()} | no_return().
+read_simple_string(simple_string, <<"OK\r\n", Rest/binary>>) ->
+  {ok, Rest};
+read_simple_string(Type, Bin) ->
+  case binary:split(Bin, <<"\r">>) of
+    [Message, <<"\n", Rest/binary>>] ->
+      {Message, Rest};
+    _Error ->
+      error({bad_resp, [Type]})
+  end.

--- a/test/eresp_coding_test.erl
+++ b/test/eresp_coding_test.erl
@@ -16,130 +16,352 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-encode_test_gen({In, Out, Options}) ->
-   fun() ->
-         ?assertEqual(Out, iolist_to_binary(eresp:encode(In, Options)))
-   end;
-encode_test_gen({In, Out}) ->
-   fun() ->
-         ?assertEqual(Out, iolist_to_binary(eresp:encode(In)))
-   end.
+encode_test_gen(Fn, {In, Out, Options}) ->
+  fun() ->
+      Got = try iolist_to_binary(eresp:Fn(In, Options))
+            catch error:Reason -> {error, Reason} end,
+      ?assertEqual(Out, Got)
+  end;
+encode_test_gen(Fn, {In, Out}) ->
+  fun() ->
+      Got = try iolist_to_binary(eresp:Fn(In))
+            catch error:Reason -> {error, Reason} end,
+      ?assertEqual(Out, Got)
+  end.
 
 encode_server_test_() ->
-   {inparallel,
+  {inparallel,
 
-    [[{Desc ++ " (encode/2)", encode_test_gen({In, Out, #{}})},
-      {Desc ++ " (encode/1)", encode_test_gen({In, Out})}]
-     || {Desc, In, Out}
-        <- [ %% { Desc, In, Out } = ServerTest
+   [[{Desc ++ " (encode/2)", encode_test_gen(encode, {In, Out, #{}})},
+     {Desc ++ " (encode/1)", encode_test_gen(encode, {In, Out})}]
+    || {Desc, In, Out}
+       <- [ %% { Desc, In, Out } = ServerTest
 
-            % Booleans -- these don't follow the convention used by redis's EVAL, but
-            % instead encode true/false as integers 1 and 0, since this disambiguates nil
-            % and false.
-            {"Encode true as the integer 1",
-             true,
-             <<":1\r\n">>},
-            {"Encode false as the integer 0",
-             false,
-             <<":0\r\n">>},
+           % Booleans -- these don't follow the convention used by redis's EVAL, but
+           % instead encode true/false as integers 1 and 0, since this disambiguates nil
+           % and false.
+           {"Encode true as the integer 1",
+            true,
+            <<":1\r\n">>},
+           {"Encode false as the integer 0",
+            false,
+            <<":0\r\n">>},
 
-            % nil is treated as a nil array
-            {"Encode nil as a nil string",
-             nil,
-             <<"$-1\r\n">>},
+           {"Encode {error, binary()} as an error",
+            {error, <<"ERROR bad message">>},
+            <<"-ERROR bad message\r\n">>},
 
-            % ok is a special case and is sent as a simple string -- this is preferable
-            % to converting it to a binary since clients often understand this as
-            % a special case. If you passed the 'client
-            {"Encode 'ok' as the simple string OK",
-             ok,
-             <<"+OK\r\n">>},
+           {"Encode {error, string()} as an error",
+            {error, "ERROR bad message"},
+            <<"-ERROR bad message\r\n">>},
 
-            % Encode binaries as bulk strings
-            {"Encode binaries as bulk strings",
-             <<"foobar">>,
-             <<"$6\r\nfoobar\r\n">>},
+           {"Encode {error, {Class, Reason}} as an error",
+            {error, {error, "bad message"}},
+            <<"-ERROR bad message\r\n">>},
 
-            {"Encode lists as lists",
-             [<<"foo">>, $b, "ar"],
-             <<"*3\r\n",
-               "$3\r\nfoo\r\n",
-               ":98\r\n",
-               "*2\r\n",
-               ":97\r\n"
-               ":114\r\n"
-               "\r\n"
-               "\r\n"
-             >>},
+           {"Encode nil as a nil string",
+            nil,
+            <<"$-1\r\n">>},
 
-            % Floats
-            {"Encoding floats as bulk strings",
-             [123.45, -123.45],
-             <<"*2\r\n"
-               "$6\r\n123.45\r\n"
-               "$7\r\n-123.45\r\n"
-               "\r\n">>},
+           % ok is a special case and is sent as a simple string -- this is preferable
+           % to converting it to a binary since clients often understand this as
+           % a special case.
+           {"Encode 'ok' as the simple string OK",
+            ok,
+            <<"+OK\r\n">>},
 
-            % Integers
-            {"Encode integers as RESP integers",
-             123456,
-             <<":123456\r\n">>},
-            {"Encode negative integers as RESP integers",
-             -123456,
-             <<":-123456\r\n">>}
-           ]]}.
+           {"Encode binaries as bulk strings",
+            <<"foobar">>,
+            <<"$6\r\nfoobar\r\n">>},
+
+           {"Encode {bulk, iolist()} tuples as bulk strings",
+            {bulk, [<<"foo">>, [$b] | "ar"]},
+            <<"$6\r\nfoobar\r\n">>},
+
+           {"Encode empty lists as empty arrays",
+            [],
+            <<"*0\r\n\r\n">>},
+
+           {"Encode lists as arrays",
+            [<<"foo">>, $b, "ar"],
+            <<"*3\r\n",
+              "$3\r\nfoo\r\n",
+              ":98\r\n",
+              "*2\r\n",
+              ":97\r\n"
+              ":114\r\n"
+              "\r\n"
+              "\r\n"
+            >>},
+
+           % Floats
+           {"Encoding floats as bulk strings",
+            [123.45, -123.45],
+            <<"*2\r\n"
+              "$6\r\n123.45\r\n"
+              "$7\r\n-123.45\r\n"
+              "\r\n">>},
+
+           % Integers
+           {"Encode integers as RESP integers",
+            123456,
+            <<":123456\r\n">>},
+           {"Encode negative integers as RESP integers",
+            -123456,
+            <<":-123456\r\n">>},
+
+           %% Invalid
+
+           {"Do not encode invalid iolists as bulk strings",
+            {bulk, [<<"foo">>, an_atom, [$b] | "ar"]},
+            {error, bad_iolist}},
+
+           {"Do not encode non-iolists as bulk strings",
+            {bulk, 123.45},
+            {error, bad_iolist}},
+
+           {"Do not encode errors with special characters (\\n; binary)",
+            {error, <<"NOPE bad\nerror">>},
+            {error, badarg}},
+
+           {"Do not encode errors with special characters (\\r; binary)",
+            {error, <<"NOPE bad\rerror">>},
+            {error, badarg}},
+
+           {"Do not encode errors with special characters (\\n; list)",
+            {error, "NOPE bad\nerror"},
+            {error, badarg}},
+
+           {"Do not encode errors with special characters (\\r; list)",
+            {error, "NOPE bad\rerror"},
+            {error, badarg}},
+
+           {"Do not encode pids",
+            self(),
+            {error, badarg}}
+
+          ]]}.
 
 cmd_test_gen({Cmd, Args}, Out) ->
-   fun() -> ?assertEqual(Out, iolist_to_binary(eresp:cmd(Cmd, Args))) end;
+  fun() -> ?assertEqual(Out, iolist_to_binary(eresp:cmd(Cmd, Args))) end;
 cmd_test_gen(Cmd, Out) ->
-   fun() -> ?assertEqual(Out, iolist_to_binary(eresp:cmd(Cmd))) end.
+  fun() -> ?assertEqual(Out, iolist_to_binary(eresp:cmd(Cmd))) end.
 
 cmd_test_() ->
-   {inparallel,
+  {inparallel,
 
-    [{Desc, cmd_test_gen(In, Out)}
-     || {Desc, In, Out}
-        <- [ %% { Desc, {Cmd, Args} | Cmd, Out } = ClientTest
+   [{Desc, cmd_test_gen(In, Out)}
+    || {Desc, In, Out}
+       <- [ %% { Desc, {Cmd, Args} | Cmd, Out } = ClientTest
 
-            %% Use ping as a simple command example
-            {"Ping (cmd/1) - atom",
-             ping,
-             <<"*1\r\n$4\r\nPING\r\n\r\n">>},
+           %% Use ping as a simple command example
+           {"Ping (cmd/1) - atom",
+            ping,
+            <<"*1\r\n$4\r\nPING\r\n\r\n">>},
 
-            {"Ping (cmd/2) - atom",
-             {ping, []},
-             <<"*1\r\n$4\r\nPING\r\n\r\n">>},
+           {"Ping (cmd/2) - atom",
+            {ping, []},
+            <<"*1\r\n$4\r\nPING\r\n\r\n">>},
 
-            {"Ping (cmd/1) - binary",
-             <<"Ping">>,
-             <<"*1\r\n$4\r\nPING\r\n\r\n">>},
+           {"Ping (cmd/1) - binary",
+            <<"Ping">>,
+            <<"*1\r\n$4\r\nPING\r\n\r\n">>},
 
-            {"Ping (cmd/1) - list",
-             "ping",
-             <<"*1\r\n$4\r\nPING\r\n\r\n">>},
+           {"Ping (cmd/1) - list",
+            "ping",
+            <<"*1\r\n$4\r\nPING\r\n\r\n">>},
 
-            {"Ping (cmd/2) - pong",
-             {ping, ["pong"]},
-             <<"*2\r\n$4\r\nPING\r\n$4\r\npong\r\n\r\n">>},
+           {"Ping (cmd/2) - pong",
+            {ping, ["pong"]},
+            <<"*2\r\n$4\r\nPING\r\n$4\r\npong\r\n\r\n">>},
 
-            {"Nested lists are iolists",
-             {rpush, ["key", ["foo", <<"bar">>]]},
-             <<"*3\r\n$5\r\nRPUSH\r\n$3\r\nkey\r\n$6\r\nfoobar\r\n\r\n">>},
+           {"Nested lists are iolists",
+            {rpush, ["key", ["foo", <<"bar">>]]},
+            <<"*3\r\n$5\r\nRPUSH\r\n$3\r\nkey\r\n$6\r\nfoobar\r\n\r\n">>},
 
-            {"All types are bulk strings",
-             {type, [-123, "list", <<"bin">>, 123.45, true, false, nil, [], <<>>, [<<>>]]},
-             <<"*11\r\n"
-               "$4\r\nTYPE\r\n"
-               "$4\r\n-123\r\n"
-               "$4\r\nlist\r\n"
-               "$3\r\nbin\r\n"
-               "$6\r\n123.45\r\n"
-               "$4\r\ntrue\r\n"
-               "$5\r\nfalse\r\n"
-               "$3\r\nnil\r\n"
-               "$0\r\n\r\n"
-               "$0\r\n\r\n"
-               "$0\r\n\r\n"
-               "\r\n">>}
+           {"All types are bulk strings",
+            {type, [-123, "list", <<"bin">>, 123.45, true, false, nil, [], <<>>, [<<>>]]},
+            <<"*11\r\n"
+              "$4\r\nTYPE\r\n"
+              "$4\r\n-123\r\n"
+              "$4\r\nlist\r\n"
+              "$3\r\nbin\r\n"
+              "$6\r\n123.45\r\n"
+              "$4\r\ntrue\r\n"
+              "$5\r\nfalse\r\n"
+              "$3\r\nnil\r\n"
+              "$0\r\n\r\n"
+              "$0\r\n\r\n"
+              "$0\r\n\r\n"
+              "\r\n">>}
 
-           ]]}.
+          ]]}.
+
+
+decode_test_gen({<<$+, _/binary>> = In, {ok, Term, _} = Out}) when Term =/= ok ->
+  % Special case -- only encoding 'ok' will produce a simple string
+  fun() -> ?assertEqual(Out, eresp:decode(In)) end;
+decode_test_gen({<<"*-1\r\n", _/binary>> = In, Out}) ->
+  % Special case --re-encoding nil will only produce a nil bulk string
+  fun() -> ?assertEqual(Out, eresp:decode(In)) end;
+decode_test_gen({In, {error, _Reason} = Out}) ->
+  % Special case -- bad input
+  fun() -> ?assertEqual(Out, eresp:decode(In)) end;
+decode_test_gen({In, {ok, WantedTerm, _} = Out}) ->
+  fun() ->
+      io:format("~w~n", [Out]),
+      {ok, GotTerm, Rest} = Decoded = eresp:decode(In),
+      ?assertEqual(Out, Decoded),
+      Encoded = iolist_to_binary(eresp:encode(WantedTerm)),
+      ?assertEqual(In, <<Encoded/binary, Rest/binary>>),
+      Reencoded = iolist_to_binary(eresp:encode(GotTerm)),
+      ?assertEqual(In, <<Reencoded/binary, Rest/binary>>)
+  end.
+
+decode_test_() ->
+  {inparallel,
+
+   [{Desc ++ " (decode/1)", decode_test_gen({In, Out})}
+    || {Desc, In, Out}
+       <- [ %% { Desc, In, Out } = DecodeTest
+
+           %% Valid payloads
+
+           {"Decode integers",
+            <<":-1234567891011121314151617181920\r\n+Trailing\r\n">>,
+            {ok, -1234567891011121314151617181920, <<"+Trailing\r\n">>}},
+
+           {"Decode arrays as lists",
+            <<"*12\r\n"
+              "*0\r\n\r\n"
+              "$5\r\nfalse\r\n"
+              "$4\r\ntrue\r\n"
+              "$2\r\nOK\r\n"
+              "-PROTO protocol error\r\n"
+              "+OK\r\n"
+              "$-1\r\n"
+              "*1\r\n" "$3\r\nfoo\r\n" "\r\n"
+              ":-12345\r\n"
+              ":12345\r\n"
+              "$6\r\n123.45\r\n"
+              ":0\r\n"
+              "\r\n+Trailing\r\n">>,
+            {ok,
+             [[],
+              <<"false">>,
+              <<"true">>,
+              <<"OK">>,
+              {error, <<"PROTO protocol error">>},
+              'ok',
+              'nil',
+              [<<"foo">>],
+              -12345,
+              12345,
+              <<"123.45">>,
+              0
+             ],
+             <<"+Trailing\r\n">>}
+           },
+
+           {"Decode errors as {error, Description} tuples",
+            <<"-ERROR decoded error\r\n+Trailing\r\n">>,
+            {ok, {error, <<"ERROR decoded error">>}, <<"+Trailing\r\n">>}},
+
+           {"Decode bulk strings as binaries",
+            <<"$15\r\nfoobar bazwub\r\n\r\n+Trailing\r\n">>,
+            {ok, <<"foobar bazwub\r\n">>, <<"+Trailing\r\n">>}},
+
+           {"Decode the simple string OK as 'ok'",
+            <<"+OK\r\n+Trailing\r\n">>,
+            {ok, 'ok', <<"+Trailing\r\n">>}},
+
+           {"Decode other simple strings as binaries",
+            <<"+PING\r\n+Trailing\r\n">>,
+            {ok, <<"PING">>, <<"+Trailing\r\n">>}},
+
+           {"Decode null arrays as 'nil'",
+            <<"*-1\r\n+Trailing\r\n">>,
+            {ok, 'nil', <<"+Trailing\r\n">>}},
+
+           {"Decode null bulks as 'nil'",
+            <<"$-1\r\n+Trailing\r\n">>,
+            {ok, 'nil', <<"+Trailing\r\n">>}},
+
+           %% Invalid payloads
+
+           {"Decode an empty binary and return eof",
+            <<>>,
+            {error, eof}},
+
+           {"Decode an invalid payload and return an error",
+            <<"Foobar+Trailing\r\n">>,
+            {error, {bad_resp, [unknown]}}},
+
+           {"Decode an invalid integer and return an error",
+            <<":123.45\r\n">>,
+            {error, {bad_resp, [integer]}}},
+
+           {"Decode an invalid integer (hex-like) and return an error",
+            <<":ff\r\n">>,
+            {error, {bad_resp, [integer]}}},
+
+           {"Decode an invalid integer (0x-hex-like) and return an error",
+            <<":0xff\r\n">>,
+            {error, {bad_resp, [integer]}}},
+
+           {"Decode an invalid integer (empty) and return an error",
+            <<":\r\n">>,
+            {error, {bad_resp, [integer]}}},
+
+           {"Decode a short bulk string and return an error",
+            <<"$12\r\nfoo\r\n$13\r\nfoobar bazwub\r\n">>,
+            {error, {bad_resp, [bulk_string]}}},
+
+           {"Decode a bulk string with no ending CRLF and return an error",
+            <<"$0\r\n">>,
+            {error, {bad_resp, [bulk_string]}}},
+
+           {"Decode a long bulk string and return an error",
+            <<"$12\r\nfoobar bazwub\r\n">>, % off by one
+            {error, {bad_resp, [bulk_string]}}},
+
+           {"Decode a bulk string with a length < -1 and return an error",
+            <<"$-13\r\nfoobar bazwub\r\n">>,
+            {error, {bad_resp, [bulk_string]}}},
+
+           {"Decode a bulk string with a malformed length and return an error",
+            <<"$12.5\r\nfoobar bazwub\r\n">>,
+            {error, {bad_resp, [bulk_string]}}},
+
+           {"Decode a simple string without a CRLF and return an error",
+            <<"+OK">>,
+            {error, {bad_resp, [simple_string]}}},
+
+           {"Decode an error without a CRLF and return an error",
+            <<"-ERROR bad error">>,
+            {error, {bad_resp, [error]}}},
+
+           {"Decode a malformed array and return an error",
+            <<"*\r\n+1\r\n">>,
+            {error, {bad_resp, [array]}}},
+
+           {"Decode a short array and return an error",
+            <<"*1\r\n\r\n">>,
+            {error, {bad_resp, [array, unknown]}}},
+
+           {"Decode an array with an invalid length and return an error",
+            <<"*1\r\n:1\r\n:2\r\n\r\n">>,
+            {error, {bad_resp, [array]}}},
+
+           {"Decode an array with a length < -1 and return an error",
+            <<"*-2\r\n:1\r\n:2\r\n\r\n">>,
+            {error, {bad_resp, [array]}}},
+
+           {"Decode an array with a malformed length and return an error",
+            <<"*0x2\r\n:1\r\n:2\r\n\r\n">>,
+            {error, {bad_resp, [array]}}},
+
+           {"Decode an invalid array and return an error",
+            <<"*1\r\nFoobar\r\n+Trailing\r\n">>,
+            {error, {bad_resp, [array, unknown]}}}
+          ]]}.


### PR DESCRIPTION
- Adds tests for decoding data and implements it for parsing binaries
  specifically. All parsing follows RESP typing more strictly than the
  encoding of client/server messages. This should bring the module up
  to approximately 100% coverage, though it doesn't cover the widest
  range of possible messages. For that, property-based testing is
  likely the way forward, or some fuzz testing.

- Adds edoc comments showing encoding / decoding for supported types.
  README now refers to the edoc for conversion tables.

- Adds a couple tests around error handling and additional function
  specs and types.

- Add server {bulk, iolist()} encoding, error tests

  Because it's fairly inconvenient to be unable to encode an iolist as
  a bulk string in a server response, {bulk, iolist()} is now a valid
  way to pass a bulk string intentionally.

- Decoding and encoding of errors is now supported as well. To encode
  an error, you need to use `{error, String}` or `{error, {Class,
  Reason}}`, where the latter will be encoded with Class in uppercase
  followed by a whitespace and the Reason string.

- When encoding errors, the simple string that it's encoded to is
  checked for CR/LF characters, as these aren't permitted in a simple
  string.

- Some unused code has been removed, particularly simple string
  encoding, since that only applies to the atom 'ok'.

- Reindents both source files to have two-space indentation. For some
  reason -- and I haven't figured this out -- the tests had 3-space
  indentation.